### PR TITLE
Re-enable Py3.10 build on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
   # Note: TWINE_PASSWORD is set in Appveyor settings
 
   matrix:
-    #- PYTHON_VERSION: 3.10
+    - PYTHON_VERSION: 3.10
     - PYTHON_VERSION: 3.9
     - PYTHON_VERSION: 3.8
     - PYTHON_VERSION: 3.7


### PR DESCRIPTION
AppVeyor now supports Python 3.10 🎉 
https://www.appveyor.com/updates/2021/11/02/

Closes #14.