### PR TITLE
Use a native tox package installation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,15 +7,8 @@ platform =
     linux: linux
     darwin: darwin
 deps =
-    pip >= 18
-    setuptools >= 40
-skip_install = true
+    pytest
+    -r requirements.txt
 passenv = *
-
-commands_pre =
-    python -m pip install pytest -r requirements.txt
-    python setup.py build_ext -i
-    python -m pip install .
-
 commands =
     python -m pytest fastrlock/tests --capture=no --strict {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ deps =
     -r requirements.txt
 passenv = *
 commands =
-    python -m pytest fastrlock/tests --capture=no --strict {posargs}
+    pytest fastrlock/tests --capture=no --strict {posargs}


### PR DESCRIPTION
That way, when we execute the commands in Fedora,
pip is not involved at all.

I haven't tested this, hence opening as draft.