### PR TITLE
ci: migrate CI workflow to cibuildwheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
-
-    - name: Install Python dependencies
-      run: python -m pip install -r requirements.txt
-
     - name: Build sdist
-      run: make sdist
+      run: |
+        python -m pip install --upgrade pip build
+        python -m build --sdist
 
     - name: Release
       uses: softprops/action-gh-release@v2
@@ -34,136 +28,31 @@ jobs:
         name: sdist
         path: dist/*.tar.gz
 
-  Linux:
-
-    strategy:
-      # Allows for matrix sub-jobs to fail without canceling the rest
-      fail-fast: false
-
-      matrix:
-        image:
-          - manylinux1_x86_64
-          - manylinux1_i686
-          - manylinux_2_24_i686
-          - manylinux_2_24_x86_64
-          - manylinux_2_28_x86_64
-          - musllinux_1_1_x86_64
-          #- manylinux_2_24_ppc64le
-          #- manylinux_2_24_s390x
-        pyversion: ["cp"]  # all CPython versions
-
-        include:
-          - image: manylinux_2_24_aarch64
-            pyversion: "cp37"
-          - image: manylinux_2_24_aarch64
-            pyversion: "cp38"
-          - image: manylinux_2_24_aarch64
-            pyversion: "cp39"
-          - image: manylinux_2_24_aarch64
-            pyversion: "cp310"
-          - image: manylinux_2_24_aarch64
-            pyversion: "cp311"
-          - image: manylinux_2_28_aarch64
-            pyversion: "cp312"
-          - image: manylinux_2_28_aarch64
-            pyversion: "cp313"
-
-          - image: musllinux_1_1_aarch64
-            pyversion: "cp37"
-          - image: musllinux_1_1_aarch64
-            pyversion: "cp38"
-          - image: musllinux_1_1_aarch64
-            pyversion: "cp39"
-          - image: musllinux_1_1_aarch64
-            pyversion: "cp310"
-          - image: musllinux_1_1_aarch64
-            pyversion: "cp311"
-          - image: musllinux_1_1_aarch64
-            pyversion: "cp312"
-          - image: musllinux_1_1_aarch64
-            pyversion: "cp313"
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
-
-    - name: Install Dependencies
-      run: |
-        python -m pip install -r requirements.txt
-
-    - name: Building wheel
-      run: |
-        make MANYLINUX_PYTHON="${{ matrix.pyversion }}*" sdist wheel_${{ matrix.image }}
-
-    - name: Copy wheels in dist
-      run: cp -v wheelhouse*/fastrlock*.whl dist/
-
-    - name: Release
-      uses: softprops/action-gh-release@v2
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: dist/*-m*linux*.whl  # manylinux / musllinux
-
-    - name: Archive Wheels
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ matrix.image }}-${{ matrix.pyversion }}
-        path: dist/  # manylinux / musllinux
-        if-no-files-found: ignore
-
-  other:
-
-    strategy:
-      # Allows for matrix sub-jobs to fail without canceling the rest
-      fail-fast: false
-
-      matrix:
-        os: [macos-latest, windows-latest]
-        python-version:
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-          - "3.14-dev"
-
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-
-    env:
-      MACOSX_DEPLOYMENT_TARGET: "11.0"
+    strategy:
+      # Allows for matrix sub-jobs to fail without canceling the rest
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.3.0
+        with:
+          output-dir: dist
 
-    - name: Install Dependencies
-      run: |
-        python -m pip install -r requirements.txt
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ./dist/*-m*linux*.whl  # manylinux / musllinux
 
-    - name: Building wheel
-      run: |
-        python setup.py bdist_wheel
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: dist/*.whl
 
-    - name: Release
-      uses: softprops/action-gh-release@v2
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: dist/*.whl
-
-    - name: Archive Wheels
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ matrix.os }}-${{ matrix.python-version }}-wheels
-        path: dist/*.whl
-        if-no-files-found: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools", "wheel",  "Cython>=3.0.11"]
+build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+test-command = "python {project}/fastrlock/tests/test_rlock.py"


### PR DESCRIPTION
Switch the CI workflow to use cibuildwheel, providing several key improvements:

- Simplifies the workflow with a modern, maintainable approach.
- Automatically handles manylinux/musllinux complexity.
- Makes it easier to add support for additional architectures in the future.
- Automatically adds support for Python 3.14 and 3.14t, resolving issues #19 and #21.

Introduce a minimal pyproject.toml. Dependencies are copied from requirements.txt into pyproject.toml for build purposes. The upper bound on Cython is removed to ensure compatibility with Python 3.14t.

We now also test the produced wheel.

Fixes: #19, #21, #23